### PR TITLE
Include requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mutagen==1.45.1
+pathvalidate==2.5.2
+PyYAML==6.0


### PR DESCRIPTION
Modules are needed to run the script, so the project should include a requirements.txt

Can be installed using `pip install -r requirements.txt`

